### PR TITLE
Base typescript/style on style, add .ts to ignored extensions

### DIFF
--- a/style.yml
+++ b/style.yml
@@ -76,6 +76,7 @@ rules:
     - error
     - always
     - js: never
+      ts: never
 
   # Enforce an empty line after last import statement.
   import/newline-after-import: error

--- a/typescript/style.yml
+++ b/typescript/style.yml
@@ -2,7 +2,9 @@
 # Licensed under the MIT license. See LICENSE file in the project root for
 # full license text.
 
-extends: ./base.yml
+extends:
+  - ../style.yml
+  - ./base.yml
 
 rules:
   # Prefer type[] over Array<type>.


### PR DESCRIPTION
Opinionated style config for TypeScript proposed in #4 was accidentally not based on primary style config.