### PR TITLE
Style update

### DIFF
--- a/style.yml
+++ b/style.yml
@@ -121,7 +121,10 @@ rules:
   lines-between-class-members: error
 
   # Limit line width to 80 columns.
-  max-len: error
+  max-len:
+    - error
+    - code: 100
+      comments: 80
 
   # Allow at most one statement per line.
   max-statements-per-line: error

--- a/typescript/style.yml
+++ b/typescript/style.yml
@@ -136,3 +136,12 @@ rules:
     - error
     - anonymous: never
       named: never
+
+  # ----------------------------------------------------------------------------
+  # Following are modifications of ../style.yml.
+
+  # This rule is mainly used to ensure that there can't accidentally be two
+  # paths in the same function one returning undefined and one a value.
+  # In TypeScript this is guaranteed by the type system, so a style lint
+  # is unnecessary.
+  consistent-return: off


### PR DESCRIPTION
While working on fixing lint errors in cnx-designer the 80 column line length limitation was quite annoying, as it contains a good number of lines like

```ts
Transforms.splitNodes(editor, { at: startPoint, match: n => n === parent })
```

which when indented exceed 80 columns, but are considerably less readable when wrapped to fit in that limit. I've also noticed, that my screen can fit up to 110 columns when I've two editors open side-by side, but can't fit 80 columns when I've thee editors open. I propose therefore that we raise line length limit to a 100 columns. I've kept limit for comments at 80 columns such comments are easier to read.

Rationale for the second change (`consistent-return`) is described in a comment:

> This rule is mainly used to ensure that there can't accidentally be two paths in the same function one returning undefined and one a value. In TypeScript this is guaranteed by the type system, so a style lint is unnecessary.